### PR TITLE
Tests

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -1,0 +1,51 @@
+name: CodeChecks
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php:
+          - '7.0'
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          - '7.4'
+
+    name: PHP ${{ matrix.php }} tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php${{ matrix.php }}-
+
+      - name: Composer
+        run: composer install --no-progress
+
+      - name: PHPUnit
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml
+
+      - name: "Upload coverage to Codecov"
+        uses: "codecov/codecov-action@v2"
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -20,9 +20,37 @@ jobs:
 
     name: PHP ${{ matrix.php }} tests
 
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_USERNAME: admin
+      DB_PASSWORD: adminpass
+      DB_DATABASE_1: test_database_1
+      DB_DATABASE_2: test_database_2
+      DB_ROOT_USERNAME: root
+      DB_ROOT_PASSWORD: rootpass
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_DATABASE: ${{ env.DB_DATABASE_1 }}
+          MYSQL_HOST: ${{ env.DB_HOST }}
+          MYSQL_USER: ${{ env.DB_USERNAME }}
+          MYSQL_PASSWORD: ${{ env.DB_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ env.DB_ROOT_PASSWORD }}
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up MySQL
+        run: |
+          mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE_2 }};' -h${{ env.DB_HOST }} -u${{ env.DB_ROOT_USERNAME }} -p${{ env.DB_ROOT_PASSWORD }}
+          mysql -e 'GRANT ALL PRIVILEGES ON ${{ env.DB_DATABASE_2 }}.* TO "${{ env.DB_USERNAME }}"@"%";' -h${{ env.DB_HOST }} -u${{ env.DB_ROOT_USERNAME }} -p${{ env.DB_ROOT_PASSWORD }}
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -44,6 +72,8 @@ jobs:
 
       - name: PHPUnit
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
+        env:
+          INTEGRATION_ENABLED: 1
 
       - name: "Upload coverage to Codecov"
         uses: "codecov/codecov-action@v2"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # phlib/schemadiff
 
-[![Latest Stable Version](https://img.shields.io/packagist/v/phlib/schemadiff.svg)](https://packagist.org/packages/phlib/schemadiff)
-[![Total Downloads](https://img.shields.io/packagist/dt/phlib/schemadiff.svg)](https://packagist.org/packages/phlib/schemadiff)
-![Licence](https://img.shields.io/github/license/phlib/schemadiff.svg?style=flat-square)
+[![Code Checks](https://img.shields.io/github/workflow/status/phlib/schemadiff/CodeChecks?logo=github)](https://github.com/phlib/schemadiff/actions/workflows/code-checks.yml)
+[![Codecov](https://img.shields.io/codecov/c/github/phlib/schemadiff.svg?logo=codecov)](https://codecov.io/gh/phlib/schemadiff)
+[![Latest Stable Version](https://img.shields.io/packagist/v/phlib/schemadiff.svg?logo=packagist)](https://packagist.org/packages/phlib/schemadiff)
+[![Total Downloads](https://img.shields.io/packagist/dt/phlib/schemadiff.svg?logo=packagist)](https://packagist.org/packages/phlib/schemadiff)
+![Licence](https://img.shields.io/github/license/phlib/schemadiff.svg)
 
 MySQL Schema Diff, a Symfony Console tool for displaying differeance between two schemas. This can be useful by showing differences between production and development. It's then up to the developer to create some kind of migration scripts.
 

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,13 @@
             "Phlib\\SchemaDiff\\": "src"
         }
     },
+    "require-dev": {
+        "phpunit/phpunit": "^6"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Phlib\\SchemaDiff\\Test\\": "tests"
+        }
+    },
     "bin": ["schemadiff"]
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    bootstrap="vendor/autoload.php"
+    beStrictAboutOutputDuringTests="true"
+    convertDeprecationsToExceptions="true"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Phlib Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,15 @@
     convertDeprecationsToExceptions="true"
     colors="true"
 >
+    <php>
+        <env name="INTEGRATION_ENABLED" value="0" />
+        <env name="DB_HOST" value="127.0.0.1" />
+        <env name="DB_PORT" value="3306" />
+        <env name="DB_USERNAME" value="" />
+        <env name="DB_PASSWORD" value="" />
+        <env name="DB_DATABASE_1" value="test_1" />
+        <env name="DB_DATABASE_2" value="test_2" />
+    </php>
     <testsuites>
         <testsuite name="Phlib Test Suite">
             <directory>tests</directory>

--- a/src/SchemaInfoFactory.php
+++ b/src/SchemaInfoFactory.php
@@ -109,25 +109,6 @@ SQL;
             ];
         }
 
-//        $sampleData = [
-//            'tableName' => [
-//                'TABLE_INFO' => [
-//                    'attribs' => 'values'
-//                ],
-//                'COLUMNS' => [
-//                    'columnName' => [
-//                        'attribs' => 'values'
-//                    ]
-//                ],
-//                'INDEXES' => [
-//                    'indexName' => [
-//                        'columns'    => 'id,etc',
-//                        'other_keys' => 'other_values'
-//                    ]
-//                ]
-//            ]
-//        ];
-
         return new SchemaInfo($schemaName, $schemaInfo, $tableData);
     }
 }

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -56,18 +56,39 @@ abstract class IntegrationTestCase extends TestCase
         return 'phlib_schemadiff_test_' . substr(sha1(uniqid()), 0, 10);
     }
 
-    final protected function createTestTable(string $schemaName, string $tableName)
-    {
+    final protected function createTestTable(
+        string $schemaName,
+        string $tableName,
+        bool $charCol = true,
+        bool $charIdx = false,
+        string $colCharset = null,
+        string $tableCharset = 'ascii'
+    ) {
         $schemaTableQuoted = '`' . $schemaName . "`.`{$tableName}`";
 
         $sql = <<<SQL
 CREATE TABLE {$schemaTableQuoted} (
   `test_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `char_col` varchar(255) DEFAULT NULL,
+SQL;
+
+        if ($charCol) {
+            $sql .= '  `char_col` varchar(255)';
+            if ($colCharset !== null) {
+                $sql .= 'CHARACTER SET ' . $colCharset;
+            }
+            $sql .= " DEFAULT NULL,\n";
+        }
+
+        $sql .= <<<SQL
   `update_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`test_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=ascii
 SQL;
+
+        if ($charIdx) {
+            $sql .= ",\n  INDEX `idx_char` (`char_col`)\n";
+        }
+
+        $sql .= ") ENGINE=InnoDB DEFAULT CHARSET={$tableCharset}";
 
         $this->pdo->query($sql);
 

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\SchemaDiff\Test\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @package phlib/schemadiff
+ */
+abstract class IntegrationTestCase extends TestCase
+{
+    /**
+     * @var \PDO
+     */
+    protected $pdo;
+
+    /**
+     * @var array
+     */
+    private $schemaTableQuoted = [];
+
+    protected function setUp()
+    {
+        if ((bool)getenv('INTEGRATION_ENABLED') !== true) {
+            static::markTestSkipped();
+            return;
+        }
+
+        parent::setUp();
+
+        $this->pdo = new \PDO(
+            'mysql:host=' . getenv('DB_HOST') . ';port=' . getenv('DB_PORT'),
+            getenv('DB_USERNAME'),
+            getenv('DB_PASSWORD'),
+            [
+                \PDO::ATTR_TIMEOUT => 2,
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+            ]
+        );
+    }
+
+    protected function tearDown()
+    {
+        foreach ($this->schemaTableQuoted as $schemaTableQuoted) {
+            $this->pdo->query("DROP TABLE {$schemaTableQuoted}");
+        }
+
+        parent::tearDown();
+    }
+
+    final protected function generateTableName(): string
+    {
+        return 'phlib_schemadiff_test_' . substr(sha1(uniqid()), 0, 10);
+    }
+
+    final protected function createTestTable(string $schemaName, string $tableName)
+    {
+        $schemaTableQuoted = '`' . $schemaName . "`.`{$tableName}`";
+
+        $sql = <<<SQL
+CREATE TABLE {$schemaTableQuoted} (
+  `test_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `char_col` varchar(255) DEFAULT NULL,
+  `update_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`test_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=ascii
+SQL;
+
+        $this->pdo->query($sql);
+
+        $this->schemaTableQuoted[] = $schemaTableQuoted;
+    }
+}

--- a/tests/Integration/SchemaDiffCommandTest.php
+++ b/tests/Integration/SchemaDiffCommandTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\SchemaDiff\Test\Integration;
+
+use Phlib\SchemaDiff\SchemaDiffCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @package phlib/schemadiff
+ * @group integration
+ *
+ * @todo This has to be an integration test because SchemaDiffCommand has hardwired dependencies on \PDO and
+ *       SchemaInfoFactory, which will instantiate a DB connection.
+ *       For now, this is a copy of the tests in Integration\SchemaDiffTest but run through the Command.
+ *       Refactoring in future to allow mock dependencies will allow coverage of more features, e.g. ignore-databases
+ */
+class SchemaDiffCommandTest extends IntegrationTestCase
+{
+    /**
+     * @var SchemaDiffCommand
+     */
+    private $command;
+
+    /**
+     * @var CommandTester
+     */
+    private $commandTester;
+
+    /**
+     * @var string
+     */
+    private $dsn1;
+
+    /**
+     * @var string
+     */
+    private $dsn2;
+
+    protected function setUp()
+    {
+        $this->command = new SchemaDiffCommand();
+
+        $application = new Application();
+        $application->add($this->command);
+
+        $this->commandTester = new CommandTester($this->command);
+
+        $dsnBase = 'h=' . getenv('DB_HOST') . ',u=' . getenv('DB_USERNAME') . ',p=' . getenv('DB_PASSWORD');
+        $this->dsn1 = $dsnBase . ',D=' . getenv('DB_DATABASE_1');
+        $this->dsn2 = $dsnBase . ',D=' . getenv('DB_DATABASE_2');
+
+        parent::setUp();
+    }
+
+    public function testSame()
+    {
+        $tableName = $this->generateTableName();
+
+        $this->createTestTable(getenv('DB_DATABASE_1'), $tableName);
+        $this->createTestTable(getenv('DB_DATABASE_2'), $tableName);
+
+        $this->commandTester->execute([
+            '--tables' => $tableName,
+            'dsn1' => $this->dsn1,
+            'dsn2' => $this->dsn2,
+        ]);
+
+        $different = $this->commandTester->getStatusCode();
+        static::assertSame(0, $different);
+
+        $output = $this->commandTester->getDisplay();
+        static::assertEmpty($output);
+    }
+
+    public function dataSchemaOrder(): array
+    {
+        return [
+            'one-two' => [1, 2],
+            'two-one' => [2, 1],
+        ];
+    }
+
+    /**
+     * @dataProvider dataSchemaOrder
+     */
+    public function testMissingTable(int $first, int $second)
+    {
+        $tableName = $this->generateTableName();
+
+        $this->createTestTable(getenv('DB_DATABASE_' . $first), $tableName);
+
+        $this->commandTester->execute([
+            '--tables' => $tableName,
+            'dsn1' => $this->dsn1,
+            'dsn2' => $this->dsn2,
+        ]);
+
+        $different = $this->commandTester->getStatusCode();
+        static::assertSame(1, $different);
+
+        $expected = "Missing table {$tableName} missing on " .
+            getenv('DB_DATABASE_' . $second) . "@{$second} exists on " . getenv('DB_DATABASE_' . $first) . "@{$first}";
+        $output = $this->commandTester->getDisplay();
+        static::assertStringStartsWith($expected, $output);
+    }
+
+    /**
+     * @dataProvider dataSchemaOrder
+     */
+    public function testMissingColumn(int $first, int $second)
+    {
+        $tableName = $this->generateTableName();
+
+        $this->createTestTable(getenv('DB_DATABASE_' . $first), $tableName, true);
+        $this->createTestTable(getenv('DB_DATABASE_' . $second), $tableName, false);
+
+        $this->commandTester->execute([
+            '--tables' => $tableName,
+            'dsn1' => $this->dsn1,
+            'dsn2' => $this->dsn2,
+        ]);
+
+        $different = $this->commandTester->getStatusCode();
+        static::assertSame(1, $different);
+
+        $expected = "Missing column {$tableName}.char_col missing on " .
+            getenv('DB_DATABASE_' . $second) . "@{$second} exists on " . getenv('DB_DATABASE_' . $first) . "@{$first}";
+        $output = $this->commandTester->getDisplay();
+        static::assertContains($expected, $output);
+    }
+
+    /**
+     * @dataProvider dataSchemaOrder
+     */
+    public function testMissingIndex(int $first, int $second)
+    {
+        $tableName = $this->generateTableName();
+
+        $this->createTestTable(getenv('DB_DATABASE_' . $first), $tableName, true, true);
+        $this->createTestTable(getenv('DB_DATABASE_' . $second), $tableName, true, false);
+
+        $this->commandTester->execute([
+            '--tables' => $tableName,
+            'dsn1' => $this->dsn1,
+            'dsn2' => $this->dsn2,
+        ]);
+
+        $different = $this->commandTester->getStatusCode();
+        static::assertSame(1, $different);
+
+        $expected = "Missing index {$tableName}.idx_char missing on " .
+            getenv('DB_DATABASE_' . $second) . "@{$second} exists on " . getenv('DB_DATABASE_' . $first) . "@{$first}";
+        $output = $this->commandTester->getDisplay();
+        static::assertStringStartsWith($expected, $output);
+    }
+
+    /**
+     * @dataProvider dataSchemaOrder
+     */
+    public function testDiffColumnCharset(int $first, int $second)
+    {
+        $tableName = $this->generateTableName();
+
+        $this->createTestTable(getenv('DB_DATABASE_' . $first), $tableName, true, false, null);
+        $this->createTestTable(getenv('DB_DATABASE_' . $second), $tableName, true, false, 'utf8mb4');
+
+        $this->commandTester->execute([
+            '--tables' => $tableName,
+            'dsn1' => $this->dsn1,
+            'dsn2' => $this->dsn2,
+        ]);
+
+        $different = $this->commandTester->getStatusCode();
+        static::assertSame(1, $different);
+
+        $expected = "Column attribute mismatch {$tableName}.char_col attribute character set differs:";
+        $output = $this->commandTester->getDisplay();
+        static::assertStringStartsWith($expected, $output);
+
+        static::assertContains(getenv('DB_DATABASE_' . $first) . "@{$first}=ascii", $output);
+        static::assertContains(getenv('DB_DATABASE_' . $second) . "@{$second}=utf8mb4", $output);
+    }
+
+    /**
+     * @dataProvider dataSchemaOrder
+     */
+    public function testDiffTableCharset(int $first, int $second)
+    {
+        $tableName = $this->generateTableName();
+
+        $this->createTestTable(getenv('DB_DATABASE_' . $first), $tableName, true, false, null, 'ascii');
+        $this->createTestTable(getenv('DB_DATABASE_' . $second), $tableName, true, false, null, 'utf8mb4');
+
+        $this->commandTester->execute([
+            '--tables' => $tableName,
+            'dsn1' => $this->dsn1,
+            'dsn2' => $this->dsn2,
+        ]);
+
+        $different = $this->commandTester->getStatusCode();
+        static::assertSame(1, $different);
+
+        $expected = "Table attribute mismatch {$tableName} attribute collation differs:";
+        $output = $this->commandTester->getDisplay();
+        static::assertStringStartsWith($expected, $output);
+
+        static::assertContains(getenv('DB_DATABASE_' . $first) . "@{$first}=ascii", $output);
+        static::assertContains(getenv('DB_DATABASE_' . $second) . "@{$second}=utf8mb4", $output);
+    }
+}

--- a/tests/Integration/SchemaDiffTest.php
+++ b/tests/Integration/SchemaDiffTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\SchemaDiff\Test\Integration;
+
+use Phlib\SchemaDiff\SchemaDiff;
+use Phlib\SchemaDiff\SchemaInfoFactory;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @package phlib/schemadiff
+ * @group integration
+ */
+class SchemaDiffTest extends IntegrationTestCase
+{
+    public function testSame()
+    {
+        $tableName = $this->generateTableName();
+
+        $this->createTestTable(getenv('DB_DATABASE_1'), $tableName);
+        $this->createTestTable(getenv('DB_DATABASE_2'), $tableName);
+
+        $tableFilter = function ($testTable) use ($tableName) {
+            return $testTable === $tableName;
+        };
+
+        $schemaInfo1 = SchemaInfoFactory::fromPdo($this->pdo, getenv('DB_DATABASE_1'), $tableFilter);
+        $schemaInfo2 = SchemaInfoFactory::fromPdo($this->pdo, getenv('DB_DATABASE_2'), $tableFilter);
+
+        $outputBuffer = new BufferedOutput();
+        $schemaDiff = new SchemaDiff($outputBuffer);
+
+        $different = $schemaDiff->diff($schemaInfo1, $schemaInfo2);
+        static::assertFalse($different);
+
+        $actual = $outputBuffer->fetch();
+        static::assertEmpty($actual);
+    }
+}

--- a/tests/SchemaDiffTest.php
+++ b/tests/SchemaDiffTest.php
@@ -1,0 +1,517 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\SchemaDiff\Test;
+
+use Phlib\SchemaDiff\SchemaDiff;
+use Phlib\SchemaDiff\SchemaInfo;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @package phlib/schemadiff
+ */
+class SchemaDiffTest extends TestCase
+{
+    /**
+     * @var OutputInterface|MockObject
+     */
+    private $output;
+
+    /**
+     * @var SchemaDiff
+     */
+    private $diff;
+
+    /**
+     * @var SchemaInfo|MockObject
+     */
+    private $schema1;
+
+    /**
+     * @var SchemaInfo|MockObject
+     */
+    private $schema2;
+
+    /**
+     * @var string
+     */
+    private $schema1Name;
+
+    /**
+     * @var string
+     */
+    private $schema2Name;
+
+    /**
+     * @dataProvider dataFormatterAddStyles
+     */
+    public function testFormatterAddStyles(array $hasStyles)
+    {
+        $formatter = $this->createMock(OutputFormatter::class);
+
+        $formatter->expects(static::exactly(5))
+            ->method('hasStyle')
+            ->withConsecutive(
+                ['schema'],
+                ['table'],
+                ['column'],
+                ['index'],
+                ['attribute']
+            )
+            ->willReturnOnConsecutiveCalls(
+                (bool)$hasStyles[0],
+                (bool)$hasStyles[1],
+                (bool)$hasStyles[2],
+                (bool)$hasStyles[3],
+                (bool)$hasStyles[4]
+            );
+
+        $newStyles = [
+            ['schema', new OutputFormatterStyle('green')],
+            ['table', new OutputFormatterStyle('blue')],
+            ['column', new OutputFormatterStyle('magenta')],
+            ['index', new OutputFormatterStyle('cyan')],
+            ['attribute', new OutputFormatterStyle('yellow')],
+        ];
+
+        $expectedStyles = array_filter($newStyles, function ($idx) use ($hasStyles) {
+            return !$hasStyles[$idx];
+        }, ARRAY_FILTER_USE_KEY);
+
+        $formatter->expects(static::exactly(count($expectedStyles)))
+            ->method('setStyle')
+            ->withConsecutive(...$expectedStyles)
+            ->willReturn(true);
+
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects(static::once())
+            ->method('getFormatter')
+            ->willReturn($formatter);
+
+        new SchemaDiff($output);
+    }
+
+    public function dataFormatterAddStyles(): array
+    {
+        $styleCount = 5;
+        $totalCombos = pow(2, $styleCount);
+        $combinations = [];
+        for ($i = 0; $i < $totalCombos; $i++) {
+            $combo = str_pad(decbin($i), $styleCount, '0', STR_PAD_LEFT);
+            $combinations['c' . $combo] = [str_split($combo)];
+        }
+        return $combinations;
+    }
+
+    public function testDiffCompareSchemaInfo()
+    {
+        $this->initDiff();
+        $this->initSchema();
+
+        $attributeName = uniqid('attr_');
+        $val1 = sha1(uniqid('one'));
+        $val2 = sha1(uniqid('two'));
+
+        $this->schema1->expects(static::once())
+            ->method('getInfo')
+            ->willReturn([
+                $attributeName => $val1,
+            ]);
+
+        $this->schema2->expects(static::once())
+            ->method('getInfo')
+            ->willReturn([
+                $attributeName => $val2,
+            ]);
+
+        $expected = [
+            "<error>Schema attribute mismatch</error> attribute <attribute>{$attributeName}</attribute> differs:",
+            "\t<schema>{$this->schema1Name}@1</schema>={$val1}",
+            "\t<schema>{$this->schema2Name}@2</schema>={$val2}"
+        ];
+        $this->output->expects(static::once())
+            ->method('writeln')
+            ->with($expected);
+
+        $hasDiff = $this->diff->diff($this->schema1, $this->schema2);
+        static::assertTrue($hasDiff);
+    }
+
+    /**
+     * @dataProvider dataSchemaOrder
+     */
+    public function testDiffHasTable(int $order1, int $order2)
+    {
+        $this->initDiff();
+        $this->initSchema();
+
+        $tableName = sha1(uniqid('table'));
+
+        // First schema has the table, second does not
+        $this->{'schema' . $order1}->expects(static::once())
+            ->method('getTables')
+            ->willReturn([
+                $tableName
+            ]);
+        // Second schema is not checked for the table if the first was missing
+        $expectation = ($order1 === 2) ? static::never() : static::once();
+        $this->{'schema' . $order1}->expects($expectation)
+            ->method('hasTable')
+            ->with($tableName)
+            ->willReturn(true);
+
+        $this->{'schema' . $order2}->expects(static::once())
+            ->method('getTables')
+            ->willReturn([]);
+
+        $this->{'schema' . $order2}->expects(static::once())
+            ->method('hasTable')
+            ->with($tableName)
+            ->willReturn(false);
+
+        $expected = "<error>Missing table</error> <table>{$tableName}</table> missing on " .
+            "<schema>{$this->{'schema' . $order2 . 'Name'}}@{$order2}</schema> exists on " .
+            "<schema>{$this->{'schema' . $order1 . 'Name'}}@{$order1}</schema>";
+
+        $this->output->expects(static::once())
+            ->method('writeln')
+            ->with($expected);
+
+        $hasDiff = $this->diff->diff($this->schema1, $this->schema2);
+        static::assertTrue($hasDiff);
+    }
+
+    public function testDiffCompareTableInfo()
+    {
+        $this->initDiff();
+        $this->initSchema();
+
+        $tableName = $this->initSchemaTable();
+
+        $attributeName = uniqid('attr_');
+        $val1 = sha1(uniqid('one'));
+        $val2 = sha1(uniqid('two'));
+
+        $this->schema1->expects(static::once())
+            ->method('getTableInfo')
+            ->with($tableName)
+            ->willReturn([
+                $attributeName => $val1,
+            ]);
+
+        $this->schema2->expects(static::once())
+            ->method('getTableInfo')
+            ->with($tableName)
+            ->willReturn([
+                $attributeName => $val2,
+            ]);
+
+        $expected = [
+            "<error>Table attribute mismatch</error> <table>{$tableName}</table> " .
+                "attribute <attribute>{$attributeName}</attribute> differs:",
+            "\t<schema>{$this->schema1Name}@1</schema>={$val1}",
+            "\t<schema>{$this->schema2Name}@2</schema>={$val2}"
+        ];
+        $this->output->expects(static::once())
+            ->method('writeln')
+            ->with($expected);
+
+        $hasDiff = $this->diff->diff($this->schema1, $this->schema2);
+        static::assertTrue($hasDiff);
+    }
+
+    /**
+     * @dataProvider dataSchemaOrder
+     */
+    public function testDiffCompareColumns(int $order1, int $order2)
+    {
+        $this->initDiff();
+        $this->initSchema();
+
+        $tableName = $this->initSchemaTable();
+
+        $columnName = sha1(uniqid('column'));
+
+        // First schema has the column, second does not
+        $this->{'schema' . $order1}->expects(static::once())
+            ->method('getColumns')
+            ->with($tableName)
+            ->willReturn([
+                $columnName
+            ]);
+        // Second schema is not checked for the column if the first was missing
+        $expectation = ($order1 === 2) ? static::never() : static::once();
+        $this->{'schema' . $order1}->expects($expectation)
+            ->method('hasColumn')
+            ->with($tableName, $columnName)
+            ->willReturn(true);
+
+        $this->{'schema' . $order2}->expects(static::once())
+            ->method('getColumns')
+            ->with($tableName)
+            ->willReturn([]);
+
+        $this->{'schema' . $order2}->expects(static::once())
+            ->method('hasColumn')
+            ->with($tableName, $columnName)
+            ->willReturn(false);
+
+        $expected = "<error>Missing column</error> " .
+                "<table>{$tableName}</table>.<column>{$columnName}</column> missing on " .
+            "<schema>{$this->{'schema' . $order2 . 'Name'}}@{$order2}</schema> exists on " .
+            "<schema>{$this->{'schema' . $order1 . 'Name'}}@{$order1}</schema>";
+
+        $this->output->expects(static::once())
+            ->method('writeln')
+            ->with($expected);
+
+        $hasDiff = $this->diff->diff($this->schema1, $this->schema2);
+        static::assertTrue($hasDiff);
+    }
+
+    public function testDiffCompareColumnInfo()
+    {
+        $this->initDiff();
+        $this->initSchema();
+
+        $tableName = $this->initSchemaTable();
+        $columnName = $this->initSchemaColumn($tableName);
+
+        $attributeName = uniqid('attr_');
+        $val1 = sha1(uniqid('one'));
+        $val2 = sha1(uniqid('two'));
+
+        $this->schema1->expects(static::once())
+            ->method('getColumnInfo')
+            ->with($tableName, $columnName)
+            ->willReturn([
+                $attributeName => $val1,
+            ]);
+
+        $this->schema2->expects(static::once())
+            ->method('getColumnInfo')
+            ->with($tableName, $columnName)
+            ->willReturn([
+                $attributeName => $val2,
+            ]);
+
+        $expected = [
+            "<error>Column attribute mismatch</error> " .
+                "<table>{$tableName}</table>.<column>{$columnName}</column> " .
+                "attribute <attribute>{$attributeName}</attribute> differs:",
+            "\t<schema>{$this->schema1Name}@1</schema>={$val1}",
+            "\t<schema>{$this->schema2Name}@2</schema>={$val2}"
+        ];
+        $this->output->expects(static::once())
+            ->method('writeln')
+            ->with($expected);
+
+        $hasDiff = $this->diff->diff($this->schema1, $this->schema2);
+        static::assertTrue($hasDiff);
+    }
+
+    /**
+     * @dataProvider dataSchemaOrder
+     */
+    public function testDiffCompareIndexes(int $order1, int $order2)
+    {
+        $this->initDiff();
+        $this->initSchema();
+
+        $tableName = $this->initSchemaTable();
+
+        $indexName = sha1(uniqid('index'));
+
+        // First schema has the column, second does not
+        $this->{'schema' . $order1}->expects(static::once())
+            ->method('getIndexes')
+            ->with($tableName)
+            ->willReturn([
+                $indexName
+            ]);
+        // Second schema is not checked for the index if the first was missing
+        $expectation = ($order1 === 2) ? static::never() : static::once();
+        $this->{'schema' . $order1}->expects($expectation)
+            ->method('hasIndex')
+            ->with($tableName, $indexName)
+            ->willReturn(true);
+
+        $this->{'schema' . $order2}->expects(static::once())
+            ->method('getIndexes')
+            ->with($tableName)
+            ->willReturn([]);
+
+        $this->{'schema' . $order2}->expects(static::once())
+            ->method('hasIndex')
+            ->with($tableName, $indexName)
+            ->willReturn(false);
+
+        $expected = "<error>Missing index</error> " .
+            "<table>{$tableName}</table>.<index>{$indexName}</index> missing on " .
+            "<schema>{$this->{'schema' . $order2 . 'Name'}}@{$order2}</schema> exists on " .
+            "<schema>{$this->{'schema' . $order1 . 'Name'}}@{$order1}</schema>";
+
+        $this->output->expects(static::once())
+            ->method('writeln')
+            ->with($expected);
+
+        $hasDiff = $this->diff->diff($this->schema1, $this->schema2);
+        static::assertTrue($hasDiff);
+    }
+
+    public function testDiffCompareIndexInfo()
+    {
+        $this->initDiff();
+        $this->initSchema();
+
+        $tableName = $this->initSchemaTable();
+        $indexName = $this->initSchemaIndex($tableName);
+
+        $attributeName = uniqid('attr_');
+        $val1 = sha1(uniqid('one'));
+        $val2 = sha1(uniqid('two'));
+
+        $this->schema1->expects(static::once())
+            ->method('getIndexInfo')
+            ->with($tableName, $indexName)
+            ->willReturn([
+                $attributeName => $val1,
+            ]);
+
+        $this->schema2->expects(static::once())
+            ->method('getIndexInfo')
+            ->with($tableName, $indexName)
+            ->willReturn([
+                $attributeName => $val2,
+            ]);
+
+        $expected = [
+            "<error>Index attribute mismatch</error> " .
+                "<table>{$tableName}</table>.<index>{$indexName}</index> " .
+                "attribute <attribute>{$attributeName}</attribute> differs:",
+            "\t<schema>{$this->schema1Name}@1</schema>={$val1}",
+            "\t<schema>{$this->schema2Name}@2</schema>={$val2}"
+        ];
+        $this->output->expects(static::once())
+            ->method('writeln')
+            ->with($expected);
+
+        $hasDiff = $this->diff->diff($this->schema1, $this->schema2);
+        static::assertTrue($hasDiff);
+    }
+
+    private function initDiff()
+    {
+        $formatter = $this->createMock(OutputFormatter::class);
+
+        $formatter->method('hasStyle')
+            ->willReturn(true);
+
+        $this->output = $this->createMock(OutputInterface::class);
+        $this->output->method('getFormatter')
+            ->willReturn($formatter);
+
+        $this->diff = new SchemaDiff($this->output);
+    }
+
+    private function initSchema()
+    {
+        $this->schema1 = $this->createMock(SchemaInfo::class);
+        $this->schema2 = $this->createMock(SchemaInfo::class);
+
+        $this->schema1Name = sha1(uniqid('one'));
+        $this->schema2Name = sha1(uniqid('two'));
+
+        $this->schema1->method('getName')
+            ->willReturn($this->schema1Name);
+
+        $this->schema2->method('getName')
+            ->willReturn($this->schema2Name);
+    }
+
+    private function initSchemaTable(): string
+    {
+        $tableName = sha1(uniqid('table'));
+
+        $this->schema1->method('getTables')
+            ->willReturn([
+                $tableName,
+            ]);
+        $this->schema1->method('hasTable')
+            ->with($tableName)
+            ->willReturn(true);
+
+        $this->schema2->method('getTables')
+            ->willReturn([
+                $tableName,
+            ]);
+        $this->schema2->method('hasTable')
+            ->with($tableName)
+            ->willReturn(true);
+
+        return $tableName;
+    }
+
+    private function initSchemaColumn(string $tableName): string
+    {
+        $columnName = sha1(uniqid('column'));
+
+        $this->schema1->method('getColumns')
+            ->with($tableName)
+            ->willReturn([
+                $columnName,
+            ]);
+        $this->schema1->method('hasColumn')
+            ->with($tableName, $columnName)
+            ->willReturn(true);
+
+        $this->schema2->method('getColumns')
+            ->with($tableName)
+            ->willReturn([
+                $columnName,
+            ]);
+        $this->schema2->method('hasColumn')
+            ->with($tableName, $columnName)
+            ->willReturn(true);
+
+        return $columnName;
+    }
+
+    private function initSchemaIndex(string $tableName): string
+    {
+        $indexName = sha1(uniqid('index'));
+
+        $this->schema1->method('getIndexes')
+            ->with($tableName)
+            ->willReturn([
+                $indexName,
+            ]);
+        $this->schema1->method('hasIndex')
+            ->with($tableName, $indexName)
+            ->willReturn(true);
+
+        $this->schema2->method('getIndexes')
+            ->with($tableName)
+            ->willReturn([
+                $indexName,
+            ]);
+        $this->schema2->method('hasIndex')
+            ->with($tableName, $indexName)
+            ->willReturn(true);
+
+        return $indexName;
+    }
+
+    public function dataSchemaOrder(): array
+    {
+        return [
+            'one-two' => [1, 2],
+            'two-one' => [2, 1],
+        ];
+    }
+}

--- a/tests/SchemaInfoFactoryTest.php
+++ b/tests/SchemaInfoFactoryTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\SchemaDiff\Test;
+
+use Phlib\SchemaDiff\SchemaInfoFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @package phlib/schemadiff
+ */
+class SchemaInfoFactoryTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private $schemaName;
+
+    /**
+     * @var string
+     */
+    private $tableName;
+
+    /**
+     * @var string[]
+     */
+    private $schemaData;
+
+    /**
+     * @var array[]
+     */
+    private $tableData;
+
+    /**
+     * @var \PDO|MockObject
+     */
+    private $pdo;
+
+    /**
+     * @var string
+     */
+    private $schemaSql;
+
+    /**
+     * @var \PDOStatement|MockObject
+     */
+    private $schemaStmt;
+
+    /**
+     * @var string
+     */
+    private $tablesSql;
+
+    /**
+     * @var string
+     */
+    private $columnsSql;
+
+    /**
+     * @var string
+     */
+    private $indexSql;
+
+    protected function setUp()
+    {
+        $this->schemaName = sha1(uniqid());
+        $this->tableName = sha1(uniqid());
+
+        $this->schemaData = [
+            'default character set' => 'utf8mb4',
+            'default collation' => 'utf8mb4_general_ci',
+        ];
+
+        $this->tableData = [
+            $this->tableName => [
+                'TABLE_INFO' => [
+                    'TABLE_NAME' => $this->tableName,
+                    'engine' => 'InnoDB',
+                    'collation' => 'utf8mb4_general_ci',
+                ],
+                'COLUMNS' => [
+                    'test_id' => [
+                        'column position' => '1',
+                        'default' => null,
+                        'nullable' => 'NO',
+                        'column type' => 'int(10) unsigned',
+                        'character set' => null,
+                        'collation' => null,
+                        'extra' => '',
+                    ],
+                ],
+                'INDEXES' => [
+                    'PRIMARY' => [
+                        'columns' => 'test_id',
+                        'unique' => 'Yes',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->pdo = $this->createMock(\PDO::class);
+
+        $this->schemaSql = <<<SQL
+SELECT
+    DEFAULT_CHARACTER_SET_NAME AS 'default character set',
+    DEFAULT_COLLATION_NAME AS 'default collation'
+FROM INFORMATION_SCHEMA.SCHEMATA
+WHERE SCHEMA_NAME = ?
+SQL;
+        $this->schemaStmt = $this->createMock(\PDOStatement::class);
+        $this->schemaStmt->method('execute')
+            ->with([$this->schemaName]);
+        $this->schemaStmt->method('fetch')
+            ->willReturn($this->schemaData);
+
+        $this->tablesSql = <<<SQL
+SELECT
+    `TABLE_NAME`,
+    `ENGINE` AS 'engine',
+    `TABLE_COLLATION` AS 'collation',
+    `TABLE_COMMENT` AS 'table comment'
+FROM `information_schema`.`TABLES`
+WHERE
+    `TABLE_SCHEMA` = ?
+SQL;
+
+        $this->columnsSql = <<<SQL
+SELECT
+    `COLUMN_NAME`,
+    `ORDINAL_POSITION` AS 'column position',
+    `COLUMN_DEFAULT` AS 'default',
+    `IS_NULLABLE` AS 'nullable',
+    `COLUMN_TYPE` AS 'column type',
+    `CHARACTER_SET_NAME` AS 'character set',
+    `COLLATION_NAME` AS 'collation',
+    `EXTRA` AS 'extra',
+    `COLUMN_COMMENT` AS 'column comment'
+
+FROM `information_schema`.`COLUMNS`
+WHERE
+    `TABLE_SCHEMA` = ?
+    AND
+    `TABLE_NAME` = ?
+SQL;
+
+        $this->indexSql = <<<SQL
+SELECT
+    `INDEX_NAME`,
+    `COLUMN_NAME`,
+    `NON_UNIQUE`
+FROM `information_schema`.`STATISTICS`
+WHERE
+    table_schema = ?
+    AND
+    table_name = ?
+ORDER BY INDEX_NAME, SEQ_IN_INDEX
+SQL;
+
+        parent::setUp();
+    }
+
+    public function testFromPdoSchemaInfo()
+    {
+        // Set up all the expected SQL queries
+        $tablesStmt = $this->createMock(\PDOStatement::class);
+        $tablesStmt->expects(static::once())
+            ->method('execute')
+            ->with([$this->schemaName]);
+        $tablesData = [
+            $this->tableData[$this->tableName]['TABLE_INFO'],
+        ];
+        $tablesStmt->expects(static::once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_ASSOC)
+            ->willReturn($tablesData);
+
+        $columnsStmt = $this->createMock(\PDOStatement::class);
+        $columnsStmt->expects(static::once())
+            ->method('execute')
+            ->with([$this->schemaName, $this->tableName]);
+        $columnsData = $this->tableData[$this->tableName]['COLUMNS'];
+        $columnsStmt->expects(static::once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_GROUP | \PDO::FETCH_UNIQUE | \PDO::FETCH_ASSOC)
+            ->willReturn($columnsData);
+
+        $indexStmt = $this->createMock(\PDOStatement::class);
+        $indexStmt->expects(static::once())
+            ->method('execute')
+            ->with([$this->schemaName, $this->tableName]);
+        $indexData = [
+            'PRIMARY' => [
+                [
+                    'COLUMN_NAME' => 'test_id',
+                    'NON_UNIQUE' => '0',
+                ],
+            ],
+        ];
+        $indexStmt->expects(static::once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_GROUP | \PDO::FETCH_ASSOC)
+            ->willReturn($indexData);
+
+        $statementMap = [
+            [
+                'with' => [$this->schemaSql],
+                'return' => $this->schemaStmt,
+            ],
+            [
+                'with' => [$this->tablesSql],
+                'return' => $tablesStmt,
+            ],
+            [
+                'with' => [$this->columnsSql],
+                'return' => $columnsStmt,
+            ],
+            [
+                'with' => [$this->indexSql],
+                'return' => $indexStmt,
+            ],
+        ];
+
+        $this->pdo->expects(static::exactly(count($statementMap)))
+            ->method('prepare')
+            ->withConsecutive(...array_column($statementMap, 'with'))
+            ->willReturnOnConsecutiveCalls(...array_column($statementMap, 'return'));
+
+        // Use the Factory to create the SchemaInfo
+        $schemaInfo = SchemaInfoFactory::fromPdo($this->pdo, $this->schemaName);
+
+        // Test the SchemaInfo constructor params:
+        // - schemaName
+        static::assertSame($this->schemaName, $schemaInfo->getName());
+
+        // - schemaData
+        static::assertSame($this->schemaData, $schemaInfo->getInfo());
+
+        // - tableData
+        static::assertSame(
+            $this->tableData[$this->tableName]['TABLE_INFO'],
+            $schemaInfo->getTableInfo($this->tableName)
+        );
+        static::assertSame(
+            $this->tableData[$this->tableName]['INDEXES']['PRIMARY'],
+            $schemaInfo->getIndexInfo($this->tableName, 'PRIMARY')
+        );
+        static::assertSame(
+            $this->tableData[$this->tableName]['COLUMNS']['test_id'],
+            $schemaInfo->getColumnInfo($this->tableName, 'test_id')
+        );
+    }
+
+    public function testFromPdoInvalidSchema()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Schema {$this->schemaName} doesn't exist");
+
+        // No result for schema statement, to trigger exception
+        $schemaStmt = $this->createMock(\PDOStatement::class);
+        $schemaStmt->expects(static::once())
+            ->method('execute')
+            ->with([$this->schemaName]);
+        $schemaStmt->expects(static::once())
+            ->method('fetch')
+            ->willReturn([]);
+
+        $this->pdo->expects(static::once())
+            ->method('prepare')
+            ->with($this->schemaSql)
+            ->willReturn($schemaStmt);
+
+        SchemaInfoFactory::fromPdo($this->pdo, $this->schemaName);
+    }
+
+    public function testFromPdoTableFilter()
+    {
+        // Set up all the expected SQL queries
+        $tablesStmt = $this->createMock(\PDOStatement::class);
+        $tablesStmt->expects(static::once())
+            ->method('execute')
+            ->with([$this->schemaName]);
+        $tablesData = [
+            $this->tableData[$this->tableName]['TABLE_INFO'],
+        ];
+        $tablesStmt->expects(static::once())
+            ->method('fetchAll')
+            ->with(\PDO::FETCH_ASSOC)
+            ->willReturn($tablesData);
+
+        $statementMap = [
+            [
+                'with' => [$this->schemaSql],
+                'return' => $this->schemaStmt,
+            ],
+            [
+                'with' => [$this->tablesSql],
+                'return' => $tablesStmt,
+            ],
+            [
+                'with' => [$this->columnsSql],
+                'return' => null,
+            ],
+            [
+                'with' => [$this->indexSql],
+                'return' => null,
+            ],
+        ];
+
+        $this->pdo->expects(static::exactly(count($statementMap)))
+            ->method('prepare')
+            ->withConsecutive(...array_column($statementMap, 'with'))
+            ->willReturnOnConsecutiveCalls(...array_column($statementMap, 'return'));
+
+        // Use the Factory to create the SchemaInfo
+        $tableFilter = function () {
+            return false;
+        };
+        $schemaInfo = SchemaInfoFactory::fromPdo($this->pdo, $this->schemaName, $tableFilter);
+
+        // No tables should be found
+        static::assertEmpty($schemaInfo->getTables());
+    }
+}

--- a/tests/SchemaInfoTest.php
+++ b/tests/SchemaInfoTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\SchemaDiff\Test;
+
+use Phlib\SchemaDiff\SchemaInfo;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @package phlib/schemadiff
+ */
+class SchemaInfoTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private $schemaName;
+
+    /**
+     * @var string
+     */
+    private $tableName;
+
+    /**
+     * @var string[]
+     */
+    private $schemaData;
+
+    /**
+     * @var array[]
+     */
+    private $tableData;
+
+    /**
+     * @var SchemaInfo
+     */
+    private $schemaInfo;
+
+    protected function setUp()
+    {
+        $this->schemaName = sha1(uniqid());
+        $this->tableName = sha1(uniqid());
+
+        $this->schemaData = [
+            'default character set' => 'utf8mb4',
+            'default collation' => 'utf8mb4_general_ci',
+        ];
+
+        $this->tableData = [
+            $this->tableName => [
+                'TABLE_INFO' => [
+                    'TABLE_NAME' => $this->tableName,
+                    'engine' => 'InnoDB',
+                    'collation' => 'utf8mb4_general_ci',
+                ],
+                'COLUMNS' => [
+                    'test_id' => [
+                        'column position' => '1',
+                        'default' => null,
+                        'nullable' => 'NO',
+                        'column type' => 'int(10) unsigned',
+                        'character set' => null,
+                        'collation' => null,
+                        'extra' => '',
+                    ],
+                ],
+                'INDEXES' => [
+                    'PRIMARY' => [
+                        'columns' => 'test_id',
+                        'unique' => 'Yes',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->schemaInfo = new SchemaInfo($this->schemaName, $this->schemaData, $this->tableData);
+
+        parent::setUp();
+    }
+
+    public function testGetName()
+    {
+        static::assertSame($this->schemaName, $this->schemaInfo->getName());
+    }
+
+    public function testGetInfo()
+    {
+        static::assertSame($this->schemaData, $this->schemaInfo->getInfo());
+    }
+
+    public function testGetTables()
+    {
+        $expected = [
+            $this->tableName,
+        ];
+
+        static::assertSame($expected, $this->schemaInfo->getTables());
+    }
+
+    public function testHasTableTrue()
+    {
+        static::assertTrue($this->schemaInfo->hasTable($this->tableName));
+    }
+
+    public function testHasTableFalse()
+    {
+        static::assertFalse($this->schemaInfo->hasTable('does-not-exist'));
+    }
+
+    public function testGetTableInfo()
+    {
+        static::assertSame(
+            $this->tableData[$this->tableName]['TABLE_INFO'],
+            $this->schemaInfo->getTableInfo($this->tableName)
+        );
+    }
+
+    public function testGetIndexes()
+    {
+        $expected = [
+            'PRIMARY',
+        ];
+
+        static::assertSame($expected, $this->schemaInfo->getIndexes($this->tableName));
+    }
+
+    public function testHasIndexTrue()
+    {
+        static::assertTrue($this->schemaInfo->hasIndex($this->tableName, 'PRIMARY'));
+    }
+
+    public function testHasIndexFalse()
+    {
+        static::assertFalse($this->schemaInfo->hasIndex($this->tableName, 'does-not-exist'));
+    }
+
+    public function testGetIndexInfo()
+    {
+        static::assertSame(
+            $this->tableData[$this->tableName]['INDEXES']['PRIMARY'],
+            $this->schemaInfo->getIndexInfo($this->tableName, 'PRIMARY')
+        );
+    }
+
+    public function testGetColumns()
+    {
+        $expected = [
+            'test_id',
+        ];
+
+        static::assertSame($expected, $this->schemaInfo->getColumns($this->tableName));
+    }
+
+    public function testHasColumnTrue()
+    {
+        static::assertTrue($this->schemaInfo->hasColumn($this->tableName, 'test_id'));
+    }
+
+    public function testHasColumnFalse()
+    {
+        static::assertFalse($this->schemaInfo->hasColumn($this->tableName, 'does-not-exist'));
+    }
+
+    public function testGetColumnInfo()
+    {
+        static::assertSame(
+            $this->tableData[$this->tableName]['COLUMNS']['test_id'],
+            $this->schemaInfo->getColumnInfo($this->tableName, 'test_id')
+        );
+    }
+}


### PR DESCRIPTION
Add unit tests and integration tests.

This is as much as can reasonably be done for now, without any refactoring to allow dependency insertion to the Command.
The main aim is to get enough coverage to then be confident in updates and refactoring when dropping old PHP versions.